### PR TITLE
Make future job check interval configurable

### DIFF
--- a/.github/workflows/todo_to_issue_manual.yml
+++ b/.github/workflows/todo_to_issue_manual.yml
@@ -1,6 +1,5 @@
 name: "Manuallly run TODO to Issue"
 on:
-    push:
     workflow_dispatch:
         inputs:
             MANUAL_COMMIT_REF:


### PR DESCRIPTION
- Make future job check interval configurable in MemBackend (fixes #11)
- Make interval of time for which jobs are dedicated a goroutine use a default in MemBackend (fixes #12)
- Make future job check interval configurable in PgBackend (fixes #18)
- Make interval of time for which jobs are dedicated a goroutine use a default in PgBackend (fixes #19)
