### PR TITLE
fix: Incorrectly passing pgx connections params to pq

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,14 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+  groups:
+  - title: Features
+    regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+    order: 0
+  - title: "Bug fixes"
+    regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+  - title: Others
+    order: 999
 
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.


### PR DESCRIPTION
Packages `pq` and `pgx` allow different connection string parameters. Since `pgx` is neoq's primary SQL library, but migrations use `pq`, we had to ensure that pgx connection parameters do not get passed to the pq library when running migrations.

This issue was introduced in version `0.20.0`.