### PR TITLE
fix: Revert "feat: Hold connections and transactions for less time"

### DIFF
--- a/backends/postgres/postgres_backend_test.go
+++ b/backends/postgres/postgres_backend_test.go
@@ -204,25 +204,27 @@ func TestBasicJobMultipleQueue(t *testing.T) {
 		t.Error(err)
 	}
 
-	jid, e := nq.Enqueue(ctx, &jobs.Job{
-		Queue: queue,
-		Payload: map[string]interface{}{
-			"message": fmt.Sprintf("hello world: %d", internal.RandInt(10000000000)),
-		},
-	})
-	if e != nil || jid == jobs.DuplicateJobID {
-		t.Error(e)
-	}
+	go func() {
+		jid, e := nq.Enqueue(ctx, &jobs.Job{
+			Queue: queue,
+			Payload: map[string]interface{}{
+				"message": fmt.Sprintf("hello world: %d", internal.RandInt(10000000000)),
+			},
+		})
+		if e != nil || jid == jobs.DuplicateJobID {
+			t.Error(e)
+		}
 
-	jid2, e := nq.Enqueue(ctx, &jobs.Job{
-		Queue: queue2,
-		Payload: map[string]interface{}{
-			"message": fmt.Sprintf("hello world: %d", internal.RandInt(10000000000)),
-		},
-	})
-	if e != nil || jid2 == jobs.DuplicateJobID {
-		t.Error(e)
-	}
+		jid2, e := nq.Enqueue(ctx, &jobs.Job{
+			Queue: queue2,
+			Payload: map[string]interface{}{
+				"message": fmt.Sprintf("hello world: %d", internal.RandInt(10000000000)),
+			},
+		})
+		if e != nil || jid2 == jobs.DuplicateJobID {
+			t.Error(e)
+		}
+	}()
 
 results_loop:
 	for {


### PR DESCRIPTION
This reverts commit bc8df98894358f7f774ea0cd4e168559c29c31e1.

This commit was totally wrong about the motivations for holding transactions throught the duration of jobs.

Ths is an embarrassing mistake because it is the crux of the entire Postgres backend. Transactions must be held while jobs are being processed because `FOR UPDATE` requires the transaction that issued the `SELECT * FOR UPDATE ...` query to remain open to hold the lock (https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS)

The reverted commit allowed jobs to be picked up by multiple workers.