### PR TITLE
fix: Bare 'make' fails due to `go vet`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ fmt:
 
 .PHONY: vet
 vet:
-	@go vet ./...
+	@go vet -tags testing ./...
 
 .PHONY: test
 test: install-gotestsum


### PR DESCRIPTION
`go vet` was missing the `testing` tag necessary to build some of the tests.

Fixes #71 