### PR TITLE
chore(test): Adding a test for multiple consumers with the pg backend.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: test
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'


### PR DESCRIPTION
This test is to provide a minimal proof that jobs can be consumed by
multiple workers and in a way can only be consumed once. If the
execCount does not match the expected count then this test will fail
because either too many jobs were executed (like one executing twice) or
a job was dropped when it should not have been.

---

I used a waitgroup for this since I want to make sure multiple jobs complete on their own time and in any order. But a
waitgroup removes any natural timeout handling and instead forces the go test process to handle timeouts instead. This
might not be ideal but would only happen when there was such a significant change to the PG backend that a job does not
get processed for some reason?

