### PR TITLE
feat: Announce jobs using PG trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: test
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/backends/postgres/migrations/20230928141356_create-new-job-trigger.down.sql
+++ b/backends/postgres/migrations/20230928141356_create-new-job-trigger.down.sql
@@ -1,0 +1,1 @@
+DROP TRIGGER IF EXISTS announce_job ON neoq_jobs CASCADE;

--- a/backends/postgres/migrations/20230928141356_create-new-job-trigger.up.sql
+++ b/backends/postgres/migrations/20230928141356_create-new-job-trigger.up.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION announce_job() RETURNS trigger AS $$
+DECLARE
+BEGIN
+  PERFORM pg_notify(CAST(NEW.queue AS text), CAST(NEW.id AS text));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER announce_job 
+  AFTER INSERT ON neoq_jobs FOR EACH ROW 
+  WHEN (NEW.run_after <= timezone('utc', NEW.created_at))
+  EXECUTE PROCEDURE announce_job();


### PR DESCRIPTION
Previously, new, non-future jobs were announced by executing `NOTIFY` in Go code. Triggers are much better suited for this, and reduces neoq complexity by allowing PG to perform notification work for most jobs.

"Future" jobs continue to use the `announceJob` method on a timer.