### PR TITLE
fix(pg): Fixed error logs for multi node cron jobs.

### DIFF
--- a/backends/postgres/postgres_backend.go
+++ b/backends/postgres/postgres_backend.go
@@ -369,7 +369,7 @@ func (p *PgBackend) StartCron(ctx context.Context, cronSpec string, h handler.Ha
 	if err = p.cron.AddFunc(cronSpec, func() {
 		_, err := p.Enqueue(ctx, &jobs.Job{Queue: queue})
 		if err != nil {
-			if errors.Is(err, context.Canceled) {
+			if errors.Is(err, context.Canceled) || errors.Is(err, ErrDuplicateJob) {
 				return
 			}
 

--- a/backends/postgres/postgres_backend_test.go
+++ b/backends/postgres/postgres_backend_test.go
@@ -425,12 +425,12 @@ func TestMultipleCronNodes(t *testing.T) {
 		workers[i] = nq
 	}
 
-	const SlightlyMoreThanOneSecond = 1100 * time.Millisecond
+	const WaitForJobTime = 1100 * time.Millisecond
 
 	// allow time for listener to start and for at least one job to process
-	time.Sleep(SlightlyMoreThanOneSecond)
+	time.Sleep(WaitForJobTime)
 	if jobsCompleted == 0 {
-		t.Fatalf("no jobs were completed after %v", SlightlyMoreThanOneSecond)
+		t.Fatalf("no jobs were completed after %v", WaitForJobTime)
 	}
 
 	if duplicateJobs > 0 {


### PR DESCRIPTION
When multiple nodes were participating as workers and a cron job was to
be enqueued, all nodes would attempt to enqueue it at the same time. As
a result all but one node would successfully enqueue the job and the
other nodes would log a message about a duplicate job. In any other
scenario this would be a log that would be good to surface, but it is
not a significant error message here as the job was still enqueued
properly.

Resolves #76

---

@acaloiaro Thoughts on testing this? I could add a test for just a multi node cron job in general and assert that it is
only performed once with multiple workers. But actually asserting that the log is not shown anymore doesn't seem like a
useful test? Let me know what your thoughts are.
