### PR TITLE
fix(pg): Fixed bug with upper-case channel names.

### DIFF
--- a/backends/postgres/postgres_backend.go
+++ b/backends/postgres/postgres_backend.go
@@ -779,6 +779,7 @@ func (p *PgBackend) listen(ctx context.Context, queue string) (c chan string, re
 
 		for {
 			notification, waitErr := conn.Conn().WaitForNotification(ctx)
+			p.logger.Debug("job notification for queue", "queue", queue, "notification", notification)
 			if waitErr != nil {
 				if errors.Is(waitErr, context.Canceled) {
 					return

--- a/backends/postgres/postgres_backend_test.go
+++ b/backends/postgres/postgres_backend_test.go
@@ -577,13 +577,13 @@ func Test_MoveJobsToDeadQueue(t *testing.T) {
 }
 
 func TestJobEnqueuedSeparately(t *testing.T) {
-	connString, conn := prepareAndCleanupDB(t)
+	connString, _ := prepareAndCleanupDB(t)
 	const queue = "SyncThing"
 	maxRetries := 5
 	done := make(chan bool)
 	defer close(done)
 
-	timeoutTimer := time.After(30 * time.Second)
+	timeoutTimer := time.After(5 * time.Second)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -613,22 +613,17 @@ func TestJobEnqueuedSeparately(t *testing.T) {
 		return
 	})
 
-	go func() {
-		err = consumer.Start(ctx, h)
-		if err != nil {
-			t.Error(err)
-		}
-	}()
+	err = consumer.Start(ctx, h)
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Wait a bit more before enqueueing
-	time.Sleep(10 * time.Second)
-	deadline := time.Now().UTC().Add(5 * time.Second)
 	jid, e := enqueuer.Enqueue(ctx, &jobs.Job{
 		Queue: queue,
 		Payload: map[string]interface{}{
 			"message": "hello world",
 		},
-		Deadline:   &deadline,
 		MaxRetries: &maxRetries,
 	})
 	if e != nil || jid == jobs.DuplicateJobID {
@@ -642,27 +637,5 @@ func TestJobEnqueuedSeparately(t *testing.T) {
 	}
 	if err != nil {
 		t.Error(err)
-	}
-
-	// ensure job has fields set correctly
-	var jdl time.Time
-	var jmxrt int
-
-	err = conn.
-		QueryRow(context.Background(), "SELECT deadline,max_retries FROM neoq_jobs WHERE id = $1", jid).
-		Scan(&jdl, &jmxrt)
-	if err != nil {
-		t.Error(err)
-	}
-
-	jdl = jdl.In(time.UTC)
-	// dates from postgres come out with only 6 decimal places of millisecond precision, naively format dates as
-	// strings for comparison reasons. Ref https://www.postgresql.org/docs/current/datatype-datetime.html
-	if jdl.Format(time.RFC3339) != deadline.Format(time.RFC3339) {
-		t.Error(fmt.Errorf("job deadline does not match its expected value: %v != %v", jdl, deadline)) // nolint: goerr113
-	}
-
-	if jmxrt != maxRetries {
-		t.Error(fmt.Errorf("job MaxRetries does not match its expected value: %v != %v", jmxrt, maxRetries)) // nolint: goerr113
 	}
 }


### PR DESCRIPTION
When the queue name is uppercase, the listener will never receive the
notification when the job is enqueued. This is done specifically with
the enqueuer and consumer being separate neoq instances (server A kicks
off a job, server B is listening to perform the work).
