### PR TITLE
chore(log): Tweaking logging again, making everything consistent

### DIFF
--- a/backends/redis/redis_backend_test.go
+++ b/backends/redis/redis_backend_test.go
@@ -296,7 +296,7 @@ func TestJobProcessingWithOptions(t *testing.T) {
 		t.Error(e)
 	}
 
-	expectedLogMsg := "error handling job [error job exceeded its 1ms timeout: context deadline exceeded]" //nolint: dupword
+	expectedLogMsg := "error handling job [error=job exceeded its 1ms timeout: context deadline exceeded]" //nolint: dupword
 	select {
 	case <-timeoutTimer:
 		err = jobs.ErrJobTimeout

--- a/neoq_test.go
+++ b/neoq_test.go
@@ -224,7 +224,7 @@ func TestSetLogger(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedLogMsg := "adding a new job [queue testing]"
+	expectedLogMsg := "adding a new job [queue=testing]"
 results_loop:
 	for {
 		select {


### PR DESCRIPTION
This is another logging change to make everything consistent. Log
key-value pairs are now done via slog's Attr format based on the notes
at the tail end here: https://go.dev/blog/slog

While this might be a more opinionated change, I see one major benefit.
If the user of the library is wrapping the logging with their own logger
that they are using (zap, logrus or any else) they would have to parse
both the alternating key value pairs and the Attr structs. By only using
the Attr structs the user would only need to handle that one object type
now in their own logging layer; hopefully making integration easier for
them to have consistent logs.

---

I'm opening this specifically because I'm using logrus for my application and I found that it was unnecessarily
complicated to try to convert both the `Attr` and the alternating key-value pairs to the logrus fields nicely?
Ultimately I'm pushing the problem upstream to this library lol, but hopefully in such a way that it would make it
easier for anyone to also implement their own logging consistently using this library.

Please let me know what your thoughts are, this is a somewhat opinionated PR in terms of logging changes. While the
output will be identical for the default logger the code has been changed throughout.
