### PR TITLE
bug(pg): Demonstrating (or trying to) bug with many crons.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test: install-gotestsum
 	@gotestsum \
 		--junitfile tmp/output/gotestsum-report.xml \
 		-- \
+		-timeout=2m \
 		-count=5 \
 		-race \
 		-cover \

--- a/backends/postgres/postgres_backend_test.go
+++ b/backends/postgres/postgres_backend_test.go
@@ -388,6 +388,9 @@ func TestMultipleCrons(t *testing.T) {
 		"3 * * * * *",
 		"4 * * * * *",
 		"5 * * * * *",
+		"6 * * * * *",
+		"7 * * * * *",
+		"8 * * * * *",
 	}
 	connString, _ := prepareAndCleanupDB(t)
 
@@ -401,7 +404,6 @@ func TestMultipleCrons(t *testing.T) {
 	// start the crons
 	for _, cron := range crons { // Start the first cron handler
 		h := handler.NewPeriodic(func(ctx context.Context) (err error) {
-			done <- true
 			return
 		})
 
@@ -415,19 +417,6 @@ func TestMultipleCrons(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-	}
-
-	// allow time for listener to start
-	time.Sleep(5 * time.Millisecond)
-
-	select {
-	case <-time.After(3 * time.Second):
-		err = errPeriodicTimeout
-	case <-done:
-	}
-
-	if err != nil {
-		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
This demonstrates an issue where it is easily possible to have more jobs or job handlers than the connection pool will allow. In tests the max conns defaults to 2 but otherwise pgxconn defaults to `runtime.NumCPU`.

I'm running into an issue where I'm running several _small_ containers with sometimes less than a single CPU core each (since I don't need much). But because of how the connection pool works this ends up causing deadlocks since the acquire function calls themselves do not have timeouts (since ctx is just cascaded throughout). 

More details can be seen here about my specific use case: https://github.com/monetr/monetr/issues/1608 

---

I guess overall, does it make sense to have a connection pool that has an arbitrary **hard** limit on connections? Even if someone were to just configure a higher limit (or maybe a significantly higher limit); most of the connections will be consumed not by jobs themselves but by the listeners associated with those jobs? Which means that you must have at least `N` max conns for `N` jobs?

The other thing would be how ctx is cascaded throughout, if I call `Start` or `StartCron` I cannot pass a `WithTimeout` context because that will cause actual parts of the handler or listener to timeout (like listening for notifications which is async anyway) where I might want to specify "the setup of this job should only take 10 seconds"?
I think the approach with how timeouts should happen with async work happening in the background vs work that is synchronous initiated by a caller should be thought about as part of this as well.