### PR TITLE
feat: Make fingerprint unique to each queue

### DIFF
--- a/backends/postgres/migrations/20240302172413_make_fingerprints_unique_to_each_queue.up.sql
+++ b/backends/postgres/migrations/20240302172413_make_fingerprints_unique_to_each_queue.up.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS neoq_jobs_fingerprint_unique_idx;
+CREATE UNIQUE INDEX IF NOT EXISTS neoq_jobs_fingerprint_unique_idx ON neoq_jobs (queue, fingerprint, status) WHERE NOT (status = 'processed');


### PR DESCRIPTION
As mentioned in #119, fingerprints should be unique to each queue, not globally. 