### PR TITLE
fix: unprocessed jobs from unwatched queues block watched queues

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,17 +12,17 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: go mod
         run: make mod
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.51
+          version: latest
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           TEST_DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable&pool_max_conns=8
           TEST_REDIS_URL: redis:6379
       - name: upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Upload test coverage
           path: tmp/coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    container: golang:1.21
+    container: golang:1.24.0
 
     steps:
       - uses: actions/checkout@v3

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -115,9 +115,7 @@ linters:
     - errchkjson
     - errname
     - errorlint
-    - execinquery
     - exhaustive
-    - exportloopref
     - funlen
     - gci
     - gocognit
@@ -125,11 +123,11 @@ linters:
     - gocritic
     - gocyclo
     # - godox
-    - goerr113
+    - err113
     - gofmt
     - goheader
     - goimports
-    - gomnd
+    - mnd
     - gomoddirectives
     - gomodguard
     - goprintffuncname
@@ -160,7 +158,6 @@ linters:
     - sqlclosecheck
     - staticcheck
     - stylecheck
-    - tenv
     - testableexamples
     #- testpackage
     - thelper

--- a/backends/memory/memory_backend.go
+++ b/backends/memory/memory_backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"sync"
 	"time"
@@ -17,7 +18,6 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/jsuar/go-cron-descriptor/pkg/crondescriptor"
 	"github.com/robfig/cron"
-	"golang.org/x/exp/slog"
 )
 
 const (

--- a/backends/memory/memory_backend_test.go
+++ b/backends/memory/memory_backend_test.go
@@ -3,6 +3,7 @@ package memory_test
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/acaloiaro/neoq/testutils"
 	"github.com/pkg/errors"
 	"github.com/robfig/cron"
-	"golang.org/x/exp/slog"
 )
 
 const (
@@ -75,7 +75,7 @@ func TestBasicJobProcessing(t *testing.T) {
 				},
 			})
 			if e != nil || jid == jobs.DuplicateJobID {
-				slog.Error("job was not enqueued. either it was duplicate or this error caused it:", e)
+				slog.Error("job was not enqueued. either it was duplicate or this error caused it:", "error", e)
 			}
 		}
 	}()
@@ -149,7 +149,7 @@ func TestBackendConfiguration(t *testing.T) {
 				},
 			})
 			if e != nil || jid == jobs.DuplicateJobID {
-				slog.Error("job was not enqueued. either it was duplicate or this error caused it:", e)
+				slog.Error("job was not enqueued. either it was duplicate or this error caused it:", "error", e)
 			}
 		}
 

--- a/backends/postgres/postgres_backend_test.go
+++ b/backends/postgres/postgres_backend_test.go
@@ -1144,7 +1144,7 @@ func TestProcessPendingJobs(t *testing.T) {
 
 	ctx := context.Background()
 
-	nq, err := neoq.New(ctx, neoq.WithBackend(postgres.Backend), postgres.WithConnectionString(connString), neoq.WithPendingJobCheckInterval(time.Duration(50*time.Millisecond)))
+	nq, err := neoq.New(ctx, neoq.WithBackend(postgres.Backend), postgres.WithConnectionString(connString), neoq.WithPendingJobCheckInterval(50*time.Millisecond))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backends/postgres/postgres_backend_test.go
+++ b/backends/postgres/postgres_backend_test.go
@@ -1144,7 +1144,11 @@ func TestProcessPendingJobs(t *testing.T) {
 
 	ctx := context.Background()
 
-	nq, err := neoq.New(ctx, neoq.WithBackend(postgres.Backend), postgres.WithConnectionString(connString), neoq.WithPendingJobCheckInterval(50*time.Millisecond))
+	nq, err := neoq.New(ctx,
+		neoq.WithBackend(postgres.Backend),
+		postgres.WithConnectionString(connString),
+		neoq.WithPendingJobCheckInterval(50*time.Millisecond),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backends/redis/redis_backend.go
+++ b/backends/redis/redis_backend.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"runtime"
 	"strings"
@@ -20,7 +21,6 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/iancoleman/strcase"
 	"github.com/jsuar/go-cron-descriptor/pkg/crondescriptor"
-	"golang.org/x/exp/slog"
 )
 
 // All jobs are placed on the same 'default' queue (until a compelling case is made for using different asynq queues

--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705697961,
-        "narHash": "sha256-XepT3WS516evSFYkme3GrcI3+7uwXHqtHbip+t24J7E=",
+        "lastModified": 1739419412,
+        "narHash": "sha256-NCWZQg4DbYVFWg+MOFrxWRaVsLA7yvRWAf6o0xPR1hI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e5d1c87f5813afde2dda384ac807c57a105721cc",
+        "rev": "2d55b4c1531187926c2a423f6940b3b1301399b5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
             packages = with pkgs; [
               automake
               gcc
-              go_1_21
+              go_1_24
               gomod2nix.legacyPackages.${system}.gomod2nix
               gotools
               golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/jsuar/go-cron-descriptor v0.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron v1.2.0
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/acaloiaro/neoq
 
-go 1.21
+go 1.24.0
 
 require (
 	github.com/golang-migrate/migrate/v4 v4.16.2

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -79,9 +79,6 @@ schema = 3
   [mod."golang.org/x/crypto"]
     version = "v0.31.0"
     hash = "sha256-ZBjoG7ZOuTEmjaXPP9txAvjAjC46DeaLs0zrNzi8EQw="
-  [mod."golang.org/x/exp"]
-    version = "v0.0.0-20230713183714-613f0c0eb8a1"
-    hash = "sha256-VLE9CCOYpTdyBWaQ1YxXpGOBS74wpIR3JJ+JVzNyEkQ="
   [mod."golang.org/x/sync"]
     version = "v0.10.0"
     hash = "sha256-HWruKClrdoBKVdxKCyoazxeQV4dIYLdkHekQvx275/o="

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"runtime"
 	"runtime/debug"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slog"
 )
 
 const (

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,7 +1,7 @@
 package logging
 
 import (
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // Logger interface is the interface that neoq's logger must implement


### PR DESCRIPTION
There could be a condition where jobs were added to a queue that is not longer being watched,
yet the jobs in those queues would continue appearing in the pending job list because
the query to get pending jobs did not filter by queues being watched.
